### PR TITLE
docs: Fix 404 link for Core Concepts

### DIFF
--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -87,5 +87,5 @@ We recommend **prai** for problems that are best solved with a structured proces
 - [Special Step Types](./special-step-types.mdx) - Learn about specialized functions for data processing
 - [Advanced Usage](./advanced-usage.mdx) - Learn about advanced features and patterns
 - [Best Practices](./best-practices.mdx) - Production guidelines and optimization tips
-- [Core Concepts](../concepts/) - Deep dive into prai's architecture
+- [Core Concepts](../concepts/step.mdx) - Deep dive into prai's architecture
 


### PR DESCRIPTION
Fixes broken url here https://pmndrs.github.io/prai/getting-started/introduction
